### PR TITLE
cccl-net-api-schema.yml can be installed in /app/src/f5-cccl

### DIFF
--- a/f5_ctlr_agent/bigipconfigdriver.py
+++ b/f5_ctlr_agent/bigipconfigdriver.py
@@ -759,7 +759,10 @@ def _find_net_schema():
         for root, dirs, files in os.walk(path):
             if NET_SCHEMA_NAME in files:
                 return os.path.join(root, NET_SCHEMA_NAME)
-    log.Error('Could not find CCCL schema: {}'.format(NET_SCHEMA_NAME))
+    for root, dirs, files in os.walk('/app/src/f5-cccl'):
+        if NET_SCHEMA_NAME in files:
+            return os.path.join(root, NET_SCHEMA_NAME)
+    log.info('Could not find CCCL schema: {}'.format(NET_SCHEMA_NAME))
     return ''
 
 


### PR DESCRIPTION
when pip upgraded and deprecated --process-dependency-links option
f5-cccl can be added in CC requirements.txt, then the
cccl-net-api-schema.yml will be copied into /app/src/f5-cccl instead of
/usr/local/lib/python2.7/site-packages/f5_cccl, this patch add
/app/src/f5-cccl as search path and resolve https://github.com/F5Networks/k8s-bigip-ctlr/issues/809
when --process-dependency-links option is removed from pip. note
cccl-net-api-schema.yml is needed when CC runs in cluster mode